### PR TITLE
Develop and integrate dynamic protocol switching mechanism based on n…

### DIFF
--- a/src/network_monitor.vhd
+++ b/src/network_monitor.vhd
@@ -1,0 +1,94 @@
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use IEEE.NUMERIC_STD.ALL;
+
+entity network_monitor is
+    Port ( 
+        clk : in STD_LOGIC;
+        rst : in STD_LOGIC;
+        can_rx : in STD_LOGIC;
+        lin_rx : in STD_LOGIC;
+        flexray_rx : in STD_LOGIC;
+        protocol_select : out STD_LOGIC_VECTOR(1 downto 0)
+    );
+end network_monitor;
+
+architecture Behavioral of network_monitor is
+    type monitor_state_type is (IDLE, CAN_DETECT, LIN_DETECT, FLEXRAY_DETECT);
+    signal state : monitor_state_type := IDLE;
+    signal counter : unsigned(15 downto 0) := (others => '0');
+    signal can_activity, lin_activity, flexray_activity : STD_LOGIC := '0';
+    
+    constant TIMEOUT : unsigned(15 downto 0) := to_unsigned(10000, 16); -- Adjust as needed
+begin
+    process(clk, rst)
+    begin
+        if rst = '1' then
+            state <= IDLE;
+            counter <= (others => '0');
+            can_activity <= '0';
+            lin_activity <= '0';
+            flexray_activity <= '0';
+            protocol_select <= "00"; -- Default to CAN
+        elsif rising_edge(clk) then
+            case state is
+                when IDLE =>
+                    counter <= (others => '0');
+                    can_activity <= '0';
+                    lin_activity <= '0';
+                    flexray_activity <= '0';
+                    state <= CAN_DETECT;
+                
+                when CAN_DETECT =>
+                    if can_rx = '0' then
+                        can_activity <= '1';
+                    end if;
+                    
+                    if counter = TIMEOUT then
+                        if can_activity = '1' then
+                            protocol_select <= "00";
+                            state <= IDLE;
+                        else
+                            state <= LIN_DETECT;
+                            counter <= (others => '0');
+                        end if;
+                    else
+                        counter <= counter + 1;
+                    end if;
+                
+                when LIN_DETECT =>
+                    if lin_rx = '0' then
+                        lin_activity <= '1';
+                    end if;
+                    
+                    if counter = TIMEOUT then
+                        if lin_activity = '1' then
+                            protocol_select <= "01";
+                            state <= IDLE;
+                        else
+                            state <= FLEXRAY_DETECT;
+                            counter <= (others => '0');
+                        end if;
+                    else
+                        counter <= counter + 1;
+                    end if;
+                
+                when FLEXRAY_DETECT =>
+                    if flexray_rx = '0' then
+                        flexray_activity <= '1';
+                    end if;
+                    
+                    if counter = TIMEOUT then
+                        if flexray_activity = '1' then
+                            protocol_select <= "10";
+                        else
+                            protocol_select <= "00"; -- Default to CAN if no activity detected
+                        end if;
+                        state <= IDLE;
+                    else
+                        counter <= counter + 1;
+                    end if;
+            end case;
+        end if;
+    end process;
+end Behavioral;

--- a/src/top_level.vhd
+++ b/src/top_level.vhd
@@ -13,8 +13,7 @@ entity top_level is
         flexray_tx : out STD_LOGIC;
         data_in : in STD_LOGIC_VECTOR(63 downto 0);
         data_out : out STD_LOGIC_VECTOR(63 downto 0);
-        data_valid : out STD_LOGIC;
-        protocol_select : in STD_LOGIC_VECTOR(1 downto 0) -- "00" for CAN, "01" for LIN, "10" for FlexRay
+        data_valid : out STD_LOGIC
     );
 end top_level;
 
@@ -26,6 +25,7 @@ architecture Behavioral of top_level is
     signal flexray_rx_internal, flexray_tx_internal : STD_LOGIC;
     signal can_data_out, lin_data_out, flexray_data_out : STD_LOGIC_VECTOR(63 downto 0);
     signal can_data_valid, lin_data_valid, flexray_data_valid : STD_LOGIC;
+    signal protocol_select : STD_LOGIC_VECTOR(1 downto 0);
 
     component clock_generator
         Port ( 
@@ -111,6 +111,17 @@ architecture Behavioral of top_level is
         );
     end component;
 
+    component network_monitor
+        Port ( 
+            clk : in STD_LOGIC;
+            rst : in STD_LOGIC;
+            can_rx : in STD_LOGIC;
+            lin_rx : in STD_LOGIC;
+            flexray_rx : in STD_LOGIC;
+            protocol_select : out STD_LOGIC_VECTOR(1 downto 0)
+        );
+    end component;
+
 begin
     clock_gen: clock_generator
         port map (
@@ -186,6 +197,16 @@ begin
             rx_out => flexray_rx_internal,
             bus_plus => flexray_rx,
             bus_minus => flexray_tx
+        );
+
+    net_monitor: network_monitor
+        port map (
+            clk => clk_1m,
+            rst => rst,
+            can_rx => can_rx,
+            lin_rx => lin_rx,
+            flexray_rx => flexray_rx,
+            protocol_select => protocol_select
         );
 
     -- Protocol selection mux


### PR DESCRIPTION
1. Added a new `network_monitor` component that detects activity on each protocol bus and selects the appropriate protocol.
2. Modified the top-level entity to include the `network_monitor` component and connect it to the protocol buses.
3. Removed the external `protocol_select` input from the top-level entity, as the selection is now done automatically by the `network_monitor`.

